### PR TITLE
Update rsync command to avoid copying files relating to the test system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ www-future: $(ACTIVATE)
 copy-to-www:
 	cd public/posts/hpo-example/code && ln -s hpo-example.chpl tune.chpl
 	start_test --clean-only
-	rsync -avh --no-times --checksum public/* $(CHPL_WWW)/chapel-lang.org/blog/ --delete
+	rsync -avh --no-times --checksum --exclude CLEANFILES --exclude "*.tmp" --exclude "*.bad" --exclude "*.future" --exclude "*.compopts" --exclude COMPOPTS --exclude "*.execopts" --exclude "EXECOPTS" --exclude "*.noexec" --exclude "sub_test" --exclude "*.notest" --exclude "*.skipif" --exclude PRECOMP --exclude "*.numlocales" --exclude "*.suppressif" --exclude Makefile --exclude NUMLOCALES --delete-excluded public/* $(CHPL_WWW)/chapel-lang.org/blog/
+	find $(CHPL_WWW)/chapel-lang.org/blog/
 
 test: check-env
 	start_test chpl-src content/posts/*/code


### PR DESCRIPTION
This assumes that we won't want to inline such files into the blog articles themselves.  If/when such a day comes, we may need to reconsider how this is done.
