### PR TITLE
Add `chplVersion: 2.4` to post that should only be tested with Chapel 2.4

### DIFF
--- a/chpl-src/announcing-chapel-2.4.chpl
+++ b/chpl-src/announcing-chapel-2.4.chpl
@@ -4,6 +4,7 @@
 // tags: ["Release Announcements", "Python", "Dyno"]
 // date: 2025-03-20
 // weight: 90
+// chplVersion: 2.4
 
 /*
 

--- a/chpl-src/announcing-chapel-2.4.good
+++ b/chpl-src/announcing-chapel-2.4.good
@@ -1,5 +1,3 @@
-announcing-chapel-2.4.chpl:261: warning: 'importModule' with a 'moduleContents' argument is deprecated. Use createModule instead.
-announcing-chapel-2.4.chpl:334: warning: 'importModule' with a 'moduleContents' argument is deprecated. Use createModule instead.
 2.4
 2.4
 2.4


### PR DESCRIPTION
Adds `chplVersion: 2.4` to a post that should only be tested with 2.4

Note: while this will prevent the test from running when it should not, I am not sure it is working as expected on `*.chpl` driven blog posts

Each section of Chapel code is not tagged with `Chapel 2.4` like it should be, only the download button at the end is.

<img width="832" height="380" alt="Screenshot 2025-09-18 at 8 45 57 AM" src="https://github.com/user-attachments/assets/2576725c-c0de-4e25-80ef-8f5703ceeb89" />


Also, python code gets tagged with `Chapel 2.4`, which doesn't really make sense

<img width="749" height="193" alt="Screenshot 2025-09-18 at 8 45 53 AM" src="https://github.com/user-attachments/assets/d1144207-73ec-464c-a577-43f5409c5cd0" />
