### PR TITLE
Show series on article pages and switch release announcements to a series.

### DIFF
--- a/chpl-src/announcing-chapel-1.29.chpl
+++ b/chpl-src/announcing-chapel-1.29.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 1.29.0!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the December 2022 release of Chapel 1.29.0"
-// tags: ["Release Announcements", "Dyno"]
+// tags: ["Dyno"]
+// series: ["Release Announcements"]
 // date: 2022-12-15
 
 /*

--- a/chpl-src/announcing-chapel-1.30.chpl
+++ b/chpl-src/announcing-chapel-1.30.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 1.30.0!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the March 2023 release of Chapel 1.30.0"
-// tags: ["Release Announcements"]
+// tags: []
+// series: ["Release Announcements"]
 // date: 2023-03-23
 
 /*

--- a/chpl-src/announcing-chapel-1.31.chpl
+++ b/chpl-src/announcing-chapel-1.31.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 1.31!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the June 2023 release of Chapel 1.31.0"
-// tags: ["Release Announcements", "Dyno"]
+// tags: ["Dyno"]
+// series: ["Release Announcements"]
 // date: 2023-06-22
 
 /*

--- a/chpl-src/announcing-chapel-1.32.chpl
+++ b/chpl-src/announcing-chapel-1.32.chpl
@@ -2,7 +2,8 @@
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the September 2023 release of Chapel 1.32.0"
 // featured: false
-// tags: ["Release Announcements", "Chapel 2.0"]
+// tags: ["Chapel 2.0"]
+// series: ["Release Announcements"]
 // date: 2023-09-28
 
 /*

--- a/chpl-src/announcing-chapel-1.33.chpl
+++ b/chpl-src/announcing-chapel-1.33.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 1.33!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the December 2023 release of Chapel 1.33.0"
-// tags: ["Release Announcements", "Chapel 2.0"]
+// tags: ["Chapel 2.0"]
+// series: ["Release Announcements"]
 // date: 2023-12-14
 // weight: 90
 

--- a/chpl-src/announcing-chapel-2.1.chpl
+++ b/chpl-src/announcing-chapel-2.1.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 2.1!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the June 2024 release of Chapel 2.1"
-// tags: ["Release Announcements"]
+// tags: []
+// series: ["Release Announcements"]
 // date: 2024-06-27
 // weight: 90
 

--- a/chpl-src/announcing-chapel-2.2.chpl
+++ b/chpl-src/announcing-chapel-2.2.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 2.2!
 // authors: ["Brad Chamberlain", "Engin Kayraklioglu"]
 // summary: "A summary of highlights from the September 2024 release of Chapel 2.2"
-// tags: ["Release Announcements", "I/O", "Parallel I/O", "Performance", "GPU Programming"]
+// tags: ["I/O", "Parallel I/O", "Performance", "GPU Programming"]
+// series: ["Release Announcements"]
 // date: 2024-09-26
 // weight: 90
 

--- a/chpl-src/announcing-chapel-2.3.chpl
+++ b/chpl-src/announcing-chapel-2.3.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 2.3!
 // authors: ["Brad Chamberlain", "Jade Abraham", "Michael Ferguson", "John Hartman"]
 // summary: "Highlights from the December 2024 release of Chapel 2.3"
-// tags: ["Release Announcements", "Python", "Sparse Arrays", "Performance", "GPU Programming", "Dyno"]
+// tags: ["Python", "Sparse Arrays", "Performance", "GPU Programming", "Dyno"]
+// series: ["Release Announcements"]
 // date: 2024-12-12
 // weight: 90
 

--- a/chpl-src/announcing-chapel-2.4.chpl
+++ b/chpl-src/announcing-chapel-2.4.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 2.4!
 // authors: ["Brad Chamberlain", "Jade Abraham", "Daniel Fedorin"]
 // summary: "Highlights from the March 2025 release of Chapel 2.4"
-// tags: ["Release Announcements", "Python", "Dyno"]
+// tags: ["Python", "Dyno"]
+// series: ["Release Announcements"]
 // date: 2025-03-20
 // weight: 90
 // chplVersion: 2.4

--- a/chpl-src/announcing-chapel-2.5.chpl
+++ b/chpl-src/announcing-chapel-2.5.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 2.5!
 // authors: ["Brad Chamberlain", "Michael Ferguson", "Lydia Duncan", "Jade Abraham", "Ben Harshbarger", "Daniel Fedorin"]
 // summary: "Highlights from the June 2025 release of Chapel 2.5"
-// tags: ["Release Announcements", "Sorting", "Performance", "Chapel 2.0", "Debugging", "Tools", "Dyno"]
+// tags: ["Sorting", "Performance", "Chapel 2.0", "Debugging", "Tools", "Dyno"]
+// series: ["Release Announcements"]
 // date: 2025-06-12
 /*
 

--- a/chpl-src/announcing-chapel-2.6.chpl
+++ b/chpl-src/announcing-chapel-2.6.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 2.6!
 // authors: ["David Longnecker", "Jade Abraham", "Lydia Duncan", "Daniel Fedorin", "Ben Harshbarger", "Brad Chamberlain"]
 // summary: "Highlights from the September 2025 release of Chapel 2.6"
-// tags: ["Release Announcements", "Interoperability", "Debugging", "Tools", "Dyno"]
+// tags: ["Interoperability", "Debugging", "Tools", "Dyno"]
+// series: ["Release Announcements"]
 // date: 2025-09-18
 /*
 

--- a/chpl-src/announcing-chapel-2.7.chpl
+++ b/chpl-src/announcing-chapel-2.7.chpl
@@ -1,7 +1,8 @@
 // Announcing Chapel 2.7!
 // authors: ["Jade Abraham", "Engin Kayraklioglu", "Daniel Fedorin", "Ben Harshbarger", "Brad Chamberlain"]
 // summary: "Highlights from the December 2025 release of Chapel 2.7"
-// tags: ["Release Announcements", "Vectorization", "Debugging", "Mason", "Tools", "Dyno"]
+// tags: ["Vectorization", "Debugging", "Mason", "Tools", "Dyno"]
+// series: ["Release Announcements"]
 // date: 2025-12-18
 /*
 

--- a/content/posts/announcing-chapel-2.0/index.md
+++ b/content/posts/announcing-chapel-2.0/index.md
@@ -1,10 +1,10 @@
 ---
 title: "Chapel 2.0: Scalable and Productive Computing for All"
 date: 2024-03-21T13:00:00-07:00
-tags: ["Chapel 2.0", "Release Announcements"]
+tags: ["Chapel 2.0"]
 featured: true
 weight: 20
-series: []
+series: ["Release Announcements"]
 summary: "This post announces Chapel 2.0, including a brief tour of what the language is capable of."
 authors: ["Daniel Fedorin"]
 ---

--- a/content/series/release-announcements/_index.md
+++ b/content/series/release-announcements/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Release Announcements"
+reverseOrder: true
+---
+
+This series contains articles detailing the highlights of Chapel's quarterly releases.

--- a/content/tags/release-announcements/_index.md
+++ b/content/tags/release-announcements/_index.md
@@ -1,5 +1,0 @@
----
-title: "Release Announcements"
----
-
-Articles detailing the highlights of Chapel's quarterly releases

--- a/themes/chapel-theme/layouts/posts/single.html
+++ b/themes/chapel-theme/layouts/posts/single.html
@@ -13,12 +13,14 @@
 <h2>{{ .Title }}</h2>
 <div class="post-subscript">
     <p>Posted on {{ .Date.Format "January 2, 2006" }}.</p>
+    {{- if .Params.tags }}
     <p>
         Tags:
         {{ range .Params.tags }}
         <a class="button" href="{{ urls.JoinPath ( $.Site.BaseURL | relLangURL ) "tags" ( . | urlize ) }}">{{ . }}</a>
         {{ end }}
     </p>
+    {{- end }}
     <p>
     By:
     {{ range $i, $e := .Params.authors -}}
@@ -26,6 +28,13 @@
     <a href="{{ urls.JoinPath ( $.Site.BaseURL | relLangURL ) "authors" ($e | urlize) }}">{{ $e }}</a>
     {{- end }}
     </p>
+    {{- if .Params.series -}}
+        {{- $series_name := (index .Params.series 0) -}}
+        {{- $series := .Site.Taxonomies.series.Get $series_name}}
+    <p>
+        Part of a series: <a href="{{ $series.Page.Permalink }}">{{ $series.Page.Title }}</a>
+    </p>
+    {{- end }}
 </div>
 {{  if .Params.interviewee_photo -}}
 </div>

--- a/themes/chapel-theme/layouts/series/list.html
+++ b/themes/chapel-theme/layouts/series/list.html
@@ -3,7 +3,7 @@
 {{ .Content }}
 
 <ul class="post-list">
-    {{ range .Pages.ByDate }}
+    {{ range (cond .Params.reverseOrder .Pages.ByDate.Reverse .Pages.ByDate) }}
     {{ partial "post.html" . }}
     {{ end }}
 </ul>


### PR DESCRIPTION
Resolves https://github.com/chapel-lang/chapel-blog/issues/31

This PR switches release announcements to a series (previously it was a tag). Besides organization, the main advantage 
of doing so is that release announcements now have a "previous" and "next" button, which I found myself wanting while browsing them. 

To make this work:

* Moved Brad's [recent tag description](https://github.com/chapel-lang/chapel-blog/pull/47) for "Release announcements" into a series description.
* Moved all "Release Announcement" tags into the "series" field. Together with the previous change, this removes the "Release Announcements" tag.
* Since some release announcements don't have additional tags, made the blog gracefully handle this case by not showing "Tags:" when there are no tags to speak of. I expect us to add tags to these articles retroactively, but I don't want to bundle that as part of this PR, or require it to happen right away.
* Added "part of a series:" to the same place where the tags field is in blog posts. This ensures that what was previously possible by clicking the "release announcement" tag is now possible by clicking the "part of a series: release announcements" link.
* Added support for showing series entries out of order. Normally I think it makes sense to show series pages in chronological order (to start at the beginning). However, for release announcements, I think it makes sense to have the most recent announcement on top.

Besides adding "Part of a series:" links to all blog posts that are part of a series, this has no additional side effects.

<img width="730" height="194" alt="Screenshot 2026-01-13 at 3 50 01 PM" src="https://github.com/user-attachments/assets/e2d21dc9-2e74-44c4-a615-86d21f83c4b1" />
<img width="793" height="481" alt="Screenshot 2026-01-13 at 3 50 17 PM" src="https://github.com/user-attachments/assets/1e5513da-d7ef-4e87-98b6-0ea2603c18ca" />
<img width="755" height="499" alt="Screenshot 2026-01-13 at 3 50 31 PM" src="https://github.com/user-attachments/assets/66104550-3ba5-4624-a27f-c4618ac95692" />

Reviewed by @bradcray -- thanks!