### PR TITLE
Tags refresh, particularly for release announcements

### DIFF
--- a/chpl-src/announcing-chapel-1.29.chpl
+++ b/chpl-src/announcing-chapel-1.29.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 1.29.0!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the December 2022 release of Chapel 1.29.0"
-// tags: ["Dyno"]
+// tags: ["Optimizations", "Libraries", "Chapel 2.0", "Dyno", "Language Features"]
 // series: ["Release Announcements"]
 // date: 2022-12-15
 

--- a/chpl-src/announcing-chapel-1.30.chpl
+++ b/chpl-src/announcing-chapel-1.30.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 1.30.0!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the March 2023 release of Chapel 1.30.0"
-// tags: []
+// tags: ["Language Features", "GPUs", "Optimizations"]
 // series: ["Release Announcements"]
 // date: 2023-03-23
 

--- a/chpl-src/announcing-chapel-1.31.chpl
+++ b/chpl-src/announcing-chapel-1.31.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 1.31!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the June 2023 release of Chapel 1.31.0"
-// tags: ["Dyno"]
+// tags: ["GPUs", "Dyno", "Chapel 2.0", "I/O"]
 // series: ["Release Announcements"]
 // date: 2023-06-22
 

--- a/chpl-src/announcing-chapel-1.32.chpl
+++ b/chpl-src/announcing-chapel-1.32.chpl
@@ -2,7 +2,7 @@
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the September 2023 release of Chapel 1.32.0"
 // featured: false
-// tags: ["Chapel 2.0"]
+// tags: ["Chapel 2.0", "GPUs", "Performance", "Co-locales", "I/O", "Portability"]
 // series: ["Release Announcements"]
 // date: 2023-09-28
 

--- a/chpl-src/announcing-chapel-1.33.chpl
+++ b/chpl-src/announcing-chapel-1.33.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 1.33!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the December 2023 release of Chapel 1.33.0"
-// tags: ["Chapel 2.0"]
+// tags: ["Chapel 2.0", "Tools", "Co-locales", "Performance"]
 // series: ["Release Announcements"]
 // date: 2023-12-14
 // weight: 90

--- a/chpl-src/announcing-chapel-2.1.chpl
+++ b/chpl-src/announcing-chapel-2.1.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 2.1!
 // authors: ["Brad Chamberlain"]
 // summary: "A summary of highlights from the June 2024 release of Chapel 2.1"
-// tags: []
+// tags: ["Portability", "Language Features", "GPUs"]
 // series: ["Release Announcements"]
 // date: 2024-06-27
 // weight: 90

--- a/chpl-src/announcing-chapel-2.2.chpl
+++ b/chpl-src/announcing-chapel-2.2.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 2.2!
 // authors: ["Brad Chamberlain", "Engin Kayraklioglu"]
 // summary: "A summary of highlights from the September 2024 release of Chapel 2.2"
-// tags: ["I/O", "Parallel I/O", "Performance", "GPU Programming"]
+// tags: ["Libraries", "I/O", "Parallel I/O", "Optimizations", "Performance", "GPUs"]
 // series: ["Release Announcements"]
 // date: 2024-09-26
 // weight: 90

--- a/chpl-src/announcing-chapel-2.3.chpl
+++ b/chpl-src/announcing-chapel-2.3.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 2.3!
 // authors: ["Brad Chamberlain", "Jade Abraham", "Michael Ferguson", "John Hartman"]
 // summary: "Highlights from the December 2024 release of Chapel 2.3"
-// tags: ["Python", "Sparse Arrays", "Performance", "GPU Programming", "Dyno"]
+// tags: ["Python", "Sparse Arrays", "Optimizations", "Performance", "GPUs", "Dyno"]
 // series: ["Release Announcements"]
 // date: 2024-12-12
 // weight: 90

--- a/chpl-src/announcing-chapel-2.4.chpl
+++ b/chpl-src/announcing-chapel-2.4.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 2.4!
 // authors: ["Brad Chamberlain", "Jade Abraham", "Daniel Fedorin"]
 // summary: "Highlights from the March 2025 release of Chapel 2.4"
-// tags: ["Python", "Dyno"]
+// tags: ["Language Features", "Python", "Tools", "Dyno"]
 // series: ["Release Announcements"]
 // date: 2025-03-20
 // weight: 90

--- a/chpl-src/announcing-chapel-2.5.chpl
+++ b/chpl-src/announcing-chapel-2.5.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 2.5!
 // authors: ["Brad Chamberlain", "Michael Ferguson", "Lydia Duncan", "Jade Abraham", "Ben Harshbarger", "Daniel Fedorin"]
 // summary: "Highlights from the June 2025 release of Chapel 2.5"
-// tags: ["Sorting", "Performance", "Chapel 2.0", "Debugging", "Tools", "Dyno"]
+// tags: ["Sorting", "Performance", "Language Features", "Chapel 2.0", "Debugging", "Tools", "Dyno"]
 // series: ["Release Announcements"]
 // date: 2025-06-12
 /*

--- a/chpl-src/announcing-chapel-2.6.chpl
+++ b/chpl-src/announcing-chapel-2.6.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 2.6!
 // authors: ["David Longnecker", "Jade Abraham", "Lydia Duncan", "Daniel Fedorin", "Ben Harshbarger", "Brad Chamberlain"]
 // summary: "Highlights from the September 2025 release of Chapel 2.6"
-// tags: ["Interoperability", "Debugging", "Tools", "Dyno"]
+// tags: ["Interoperability", "Libraries", "Debugging", "Tools", "Dyno"]
 // series: ["Release Announcements"]
 // date: 2025-09-18
 /*

--- a/chpl-src/announcing-chapel-2.7.chpl
+++ b/chpl-src/announcing-chapel-2.7.chpl
@@ -1,7 +1,7 @@
 // Announcing Chapel 2.7!
 // authors: ["Jade Abraham", "Engin Kayraklioglu", "Daniel Fedorin", "Ben Harshbarger", "Brad Chamberlain"]
 // summary: "Highlights from the December 2025 release of Chapel 2.7"
-// tags: ["Vectorization", "Debugging", "Mason", "Tools", "Dyno"]
+// tags: ["Vectorization", "Debugging", "Tools", "Mason", "Dyno"]
 // series: ["Release Announcements"]
 // date: 2025-12-18
 /*

--- a/chpl-src/gpus-mandelbrot.chpl
+++ b/chpl-src/gpus-mandelbrot.chpl
@@ -1,5 +1,5 @@
 // Generating the Mandelbrot with Chapel's GPU Support
-// tags: ["GPU Programming", "Tutorial"]
+// tags: ["GPUs", "Tutorial"]
 // series: ["GPU Programming in Chapel"]
 // summary: "This post continues to introduce Chapel's GPU programming features by generating a fractal"
 // authors: ["Daniel Fedorin"]

--- a/chpl-src/intro-to-gpus.chpl
+++ b/chpl-src/intro-to-gpus.chpl
@@ -1,5 +1,5 @@
 // Introduction to GPU Programming in Chapel
-// tags: ["GPU Programming", "How-To"]
+// tags: ["GPUs", "How-To"]
 // series: ["GPU Programming in Chapel"]
 // summary: "This post gives a beginner's introduction to Chapel's GPU programming features"
 // featured: true

--- a/content/posts/10myths-part2/index.md
+++ b/content/posts/10myths-part2/index.md
@@ -1,7 +1,7 @@
 ---
 title: "10 Myths About Scalable Parallel Programming Languages (Redux),  Part 2: Past Failures and Future Attempts"
 date: 2025-05-28
-tags: ["Editorial", "Archival Posts / Reprints", "GPU Programming"]
+tags: ["Editorial", "Archival Posts / Reprints", "GPUs"]
 series: ["10 Myths About Scalable Parallel Programming Languages Redux"]
 summary: "Another archival post from the IEEE TCSC blog in 2012, with a current reflection on it"
 authors: ["Brad Chamberlain"]

--- a/content/posts/10myths-part3/index.md
+++ b/content/posts/10myths-part3/index.md
@@ -1,7 +1,7 @@
 ---
 title: "10 Myths About Scalable Parallel Programming Languages (Redux),  Part 3: New Languages vs. Language Extensions"
 date: 2025-06-25
-tags: ["Editorial", "Archival Posts / Reprints", "GPU Programming"]
+tags: ["Editorial", "Archival Posts / Reprints", "GPUs"]
 series: ["10 Myths About Scalable Parallel Programming Languages Redux"]
 summary: "A third archival post from the 2012 IEEE TCSC blog series, with a current reflection on it"
 authors: ["Brad Chamberlain"]

--- a/content/posts/7qs-bachman/index.md
+++ b/content/posts/7qs-bachman/index.md
@@ -1,7 +1,7 @@
 ---
 title: "7 Questions for Scott Bachman: Analyzing Coral Reefs with Chapel"
 date: 2024-10-01
-tags: ["Earth Sciences", "Image Analysis", "GPU Programming", "User Experiences", "Interviews"]
+tags: ["Earth Sciences", "Image Analysis", "GPUs", "User Experiences", "Interviews"]
 series: ["7 Questions for Chapel Users"]
 summary: "An interview with oceanographer Scott Bachman, focusing on his work to measure coral reef biodiversity using satellite image analysis"
 authors: ["Brad Chamberlain", "Engin Kayraklioglu"]

--- a/content/posts/announcing-chapel-2.0/index.md
+++ b/content/posts/announcing-chapel-2.0/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Chapel 2.0: Scalable and Productive Computing for All"
 date: 2024-03-21T13:00:00-07:00
-tags: ["Chapel 2.0"]
+tags: ["Chapel 2.0", "Arkouda", "Sorting", "Performance", "Computational Fluid Dynamics", "Earth Sciences", "Benchmarks", "Tools"]
 featured: true
 weight: 20
 series: ["Release Announcements"]

--- a/content/posts/gpu-data-movement/index.md
+++ b/content/posts/gpu-data-movement/index.md
@@ -2,7 +2,7 @@
 title: "Chapel's High-Level Support for CPU-GPU Data Transfers and Multi-GPU
         Programming"
 date: 2024-04-25
-tags: ["GPU Programming", "How-To"]
+tags: ["GPUs", "How-To"]
 series: ["GPU Programming in Chapel"]
 summary: "This post covers how Chapel's arrays, parallelism, and locality features
 enable moving data between CPUs and GPUs."

--- a/content/posts/nvidia-gpu-wsl/index.md
+++ b/content/posts/nvidia-gpu-wsl/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Measure the Performance of your Gaming GPU with Chapel"
 date: 2024-08-27
-tags: ["GPU Programming", "How-to", "Windows"]
+tags: ["GPUs", "How-to", "Windows"]
 series: ["GPU Programming in Chapel"]
 summary: "This post demonstrates using the Windows Subsystem for Linux to run Chapel code on a GPU from NVIDIA"
 authors: ["Ahmad Rezaii"]

--- a/content/tags/co-locales/_index.md
+++ b/content/tags/co-locales/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Co-locales"
+---
+
+Articles about [co-locales](https://chapel-lang.org/docs/usingchapel/multilocale.html#co-locales), in which multiple locales share a compute node

--- a/content/tags/gpu-programming/_index.md
+++ b/content/tags/gpu-programming/_index.md
@@ -1,6 +1,0 @@
----
-title: "GPU Programming"
----
-
-Articles about using Chapel to write GPU computations
-

--- a/content/tags/gpus/_index.md
+++ b/content/tags/gpus/_index.md
@@ -1,0 +1,5 @@
+---
+title: "GPUs"
+---
+
+Articles about GPU programming and computing with Chapel 

--- a/content/tags/language-features/_index.md
+++ b/content/tags/language-features/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Language Features"
+---
+
+Articles introducing new language features in Chapel

--- a/content/tags/libraries/_index.md
+++ b/content/tags/libraries/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Libraries"
+---
+
+Articles about library-based features in Chapel, such as standard and package modules

--- a/content/tags/optimizations/_index.md
+++ b/content/tags/optimizations/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Optimizations"
+---
+
+Articles about performance optimizations for Chapel programs

--- a/content/tags/portability/_index.md
+++ b/content/tags/portability/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Portability"
+---
+
+Articles about Chapel's portability across platforms or via installation mechanisms


### PR DESCRIPTION
In early release announcements, we didn't really use (m)any tags other than "Release Announcement".  Now that that's been converted from a tag into the series, I've gone back and added tags to these old articles, taking a pass on the release announcements tags as a whole and introducing some new ones for "Language Features", "Libraries", and "Optimizations", which are nice for things like "editions" or "the Image module" for whom a specific tag isn't likely to get a lot of use, but which should still get credit for what they contribute to the announcement.

While here, I also shortened "GPU Programming" to "GPUs" for brevity/simplicity since I don't think it needs to be as verbose and self-sufficient anymore now that we have tag descriptions (if it ever did).
