### PR TITLE
Skip converter test when network atomics are available

### DIFF
--- a/content/posts/announcing-chapel-2.7/code/converter.skipif
+++ b/content/posts/announcing-chapel-2.7/code/converter.skipif
@@ -1,1 +1,2 @@
 CHPL_LLVM==none
+CHPL_NETWORK_ATOMICS!=none


### PR DESCRIPTION
The code path for network atomics happens to run into a bug in the converter, which causes the test to fail.