### PR TITLE
Adjust sidenotes to not rely on border width subtraction

### DIFF
--- a/themes/chapel-theme/assets/scss/sidenotes.scss
+++ b/themes/chapel-theme/assets/scss/sidenotes.scss
@@ -3,7 +3,7 @@
 @import "margin.scss";
 
 $sidenote-padding: 1rem;
-$sidenote-highlight-border-width: .2rem;
+$sidenote-highlight-border-width: $standard-border-width;
 
 .sidenote {
     &:hover {
@@ -13,10 +13,11 @@ $sidenote-highlight-border-width: .2rem;
         }
 
         .sidenote-content {
-            border: $sidenote-highlight-border-width dashed;
+            border: $sidenote-highlight-border-width solid;
             padding: $sidenote-padding -
                 ($sidenote-highlight-border-width - $standard-border-width);
             border-color: $primary-color;
+            box-shadow: 0 0 0.4rem rgba(darken($primary-color, 20%), 0.3);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel-blog/issues/26.

[As I outlined in the issue:](https://github.com/chapel-lang/chapel-blog/issues/26#issuecomment-3946485010)

> The reason you're still seeing the issue is that borders (and borders in particular) are rounded by the browser to device pixel boundaries. Thus, the computation for the [smaller padding to compensate for the bigger border] doesn't exactly match the change in border width. The end result is a barely-noticeable layout shift.

> There's no way to soundly fix this since rounding behavior depends on display, pixel density, and zoom. Instead, I can change our style to change the border color and add a drop shadow to highlight the hovered-over note. This precludes the need for the computation I described (because the border width now remains constant), and thus removes any place where rounding can make its way in.

This PR does this.

| No Hover | Old Hover | New Hover |
|-|-|-|
|![notenohover](https://github.com/user-attachments/assets/df2e6830-2bd2-4f39-b750-1d6fb339a13b)|![noteoldhover](https://github.com/user-attachments/assets/d65ff3cd-a15d-4fde-9065-615ae2ded0ca)|![notenewhover](https://github.com/user-attachments/assets/9cef7c6f-ba53-42b8-8f1f-bd76b1909aed)|

I think it looks pretty nice:

<img width="1034" height="476" alt="Screenshot 2026-02-23 at 10 34 02 AM" src="https://github.com/user-attachments/assets/bf17a322-2dfe-40d2-9cae-417cba8d9ac3" />

Reviewed by @benharsh -- thanks!

## Testing
- [x] hover no longer changes line breaks in sidenotes on any zoom level I tried in the 10 myths, part 7 post from the original issue.
