### PR TITLE
Trim link titles in next/previous buttons for 10 myths series

### DIFF
--- a/themes/chapel-theme/layouts/partials/series-item-name.html
+++ b/themes/chapel-theme/layouts/partials/series-item-name.html
@@ -1,5 +1,7 @@
 {{ if and (strings.Contains .name "Advent of Code 2022, Day") (eq .series "Advent of Code 2022") }}
 {{ strings.TrimPrefix "Advent of Code 2022," .name }}
+{{ else if and (strings.Contains .name "10 Myths About Scalable Parallel Programming Languages (Redux),") (eq .series "10 Myths About Scalable Parallel Programming Languages Redux") }}
+{{ strings.TrimPrefix "10 Myths About Scalable Parallel Programming Languages (Redux)," .name }}
 {{ else }}
 {{ .name }}
 {{ end }}


### PR DESCRIPTION
Adjust our purpose-built template for intra-series linking to recognize the 10 myths series and trim links from redundant text.

Reviewed by @jabraham17 -- thanks!

Before: 
<img width="1430" height="352" alt="image" src="https://github.com/user-attachments/assets/0368c169-e4fc-4dbd-9a9e-f85c717a849a" />

After:
<img width="1402" height="218" alt="image" src="https://github.com/user-attachments/assets/d378eaf2-f176-49ed-a285-52e8b03d584c" />
