### PR TITLE
Only show 'tested for Chapel X.Y' tooltip for Chapel files

### DIFF
--- a/themes/chapel-theme/layouts/partials/version-tooltip.html
+++ b/themes/chapel-theme/layouts/partials/version-tooltip.html
@@ -1,0 +1,8 @@
+{{- $chpl_version := .Page.Param "chplVersion" -}}
+
+{{- if (and (not (eq nil $chpl_version ) ) (in (slice "chpl" "chapel") (.Get "lang" | lower))) }}
+    <div class="tooltip">
+        Chapel {{ $chpl_version }}
+        <span class="tooltiptext">Warning: this code is only tested up to Chapel version {{ $chpl_version }}</span>
+    </div>
+{{- end -}}

--- a/themes/chapel-theme/layouts/shortcodes/file_download.html
+++ b/themes/chapel-theme/layouts/shortcodes/file_download.html
@@ -1,17 +1,11 @@
 {{ $static_path := path.Join (.Page.File.Dir) "/code/" (.Get "fname") }}
 {{ $dynamic_path := path.Join "code/" (.Get "fname")}}
-{{ $chpl_version := .Page.Param "chplVersion"}}
 {{ $highlight := .Get "highlight" }}
 
 <div class="file" data-code-type="main" data-code-path="code/{{ .Get "fname" }}" data-start-line=1>
     <div class="file-header">
         <a href={{ $dynamic_path }} download="{{ .Get "fname" }}">{{ .Get "fname" }}</a>
-        {{ if (and (not (eq nil $chpl_version ) ) (in (slice "chpl" "chapel") (.Get "lang" | lower))) }}
-            <div class="tooltip">
-                Chapel {{ $chpl_version }}
-                <span class="tooltiptext">Warning: this code is only tested up to Chapel version {{ $chpl_version }}</span>
-            </div>
-        {{ end }}
+        {{ partial "version-tooltip.html" . }}
     </div>
 
     {{ $file := readFile $static_path | safeHTML }}

--- a/themes/chapel-theme/layouts/shortcodes/file_download_min.html
+++ b/themes/chapel-theme/layouts/shortcodes/file_download_min.html
@@ -1,18 +1,12 @@
 {{ $static_path := path.Join (.Page.File.Dir) "/code/" (.Get "fname") }}
 {{ $dynamic_path := path.Join "code/" (.Get "fname")}}
-{{ $chpl_version := .Page.Param "chplVersion"}}
 {{- $open := .Get "open" }}
 
 <div class="file" data-code-type="main" data-code-path="code/{{ .Get "fname" }}" data-start-line=1>
     <details {{- if $open }} open {{ end }}>
         <summary class="file-header">
             <a href={{ $dynamic_path }} download="{{ .Get "fname" }}">{{ .Get "fname" }}</a>
-            {{ if (and (not (eq nil $chpl_version ) ) (in (slice "chpl" "chapel") (.Get "lang" | lower))) }}
-                <div class="tooltip">
-                    Chapel {{ $chpl_version }}
-                    <span class="tooltiptext">Warning: this code is only tested up to Chapel version {{ $chpl_version }}</span>
-                </div>
-            {{ end }}
+            {{ partial "version-tooltip.html" . }}
         </summary>
         {{ $file := readFile $static_path | safeHTML }}
         {{ highlight $file (.Get "lang") "lineNos=true"}}

--- a/themes/chapel-theme/layouts/shortcodes/whole_file_min.html
+++ b/themes/chapel-theme/layouts/shortcodes/whole_file_min.html
@@ -1,17 +1,11 @@
 {{ $fname := printf "%s.chpl" .Page.File.ContentBaseName }}
 {{ $static_path := path.Join (.Page.File.Dir) "/code/" $fname }}
-{{ $chpl_version := .Page.Param "chplVersion"}}
 
 <div class="file" data-code-type="main">
     <details>
         <summary class="file-header">
             <a href="./code/{{ $fname }}" download="{{ $fname }}">{{ $fname }}</a>
-            {{ if (and (not (eq nil $chpl_version ) ) (in (slice "chpl" "chapel") (.Get "lang" | lower))) }}
-                <div class="tooltip">
-                    Chapel {{ $chpl_version }}
-                    <span class="tooltiptext">Warning: this code is only tested up to Chapel version {{ $chpl_version }}</span>
-                </div>
-            {{ end }}
+            {{ partial "version-tooltip.html" . }}
         </summary>
         {{ $file := readFile $static_path | safeHTML }}
         {{ highlight $file "chpl" "lineNos=true"}}


### PR DESCRIPTION
Closes https://github.com/chapel-lang/chapel-blog/issues/22.

Simply checks whether the code block being inserted is for `chpl`, `chapel`, `Chapel`, etc.

While there, notice that the same code is repeated 3 times in various files, and extract it into a single partial.

Reviewed by @jabraham17 -- thanks!

## Testing
- [x] tooltip disappears from the `.py` file where it was previously
- [x] other tooltips remain
- some spaces due to liberal templating disappear