### PR TITLE
Add the February 2026 newsletter as an external article

### DIFF
--- a/content/posts/newsletter-february26/index.md
+++ b/content/posts/newsletter-february26/index.md
@@ -1,0 +1,9 @@
+---
+title: "Chapel Newsletter - February 2026"
+date: 2026-02-23
+tags: ["External Posts", "Community", "Newsletter"]
+summary: "Chapel's quarterly newsletter, with highlights from HPSFCon and SC"
+externalURL: "https://chapel.discourse.group/t/chapel-newsletter-february-2026/47986"
+---
+
+This is the February 2026 newsletter.


### PR DESCRIPTION
Adds the [recent newsletter](https://chapel.discourse.group/t/chapel-newsletter-february-2026/47986) as an external article.