### PR TITLE
Force a linebreak so that the "External Article" button appears on its own line

### DIFF
--- a/themes/chapel-theme/layouts/partials/post.html
+++ b/themes/chapel-theme/layouts/partials/post.html
@@ -7,7 +7,7 @@
         {{- if .Params.featured }}{{ partial "icon.html" "star" }}{{ end }}
         {{- " " -}}{{ partial "richtitle.html" . }}
         {{- if .Params.externalURL -}}
-        <span class="external-marker">
+        <br><span class="external-marker">
             External Article {{ partial "icon.html" "external-link" }}
         </span>
         {{- end -}}


### PR DESCRIPTION
To me, this made article titles easier to parse while also making the external article visual tag clearer.

### Before
<img width="1126" height="1900" alt="image" src="https://github.com/user-attachments/assets/1ea9dcd6-dcfb-4ef9-a118-734c6a61e200" />

### After
<img width="1120" height="1872" alt="image" src="https://github.com/user-attachments/assets/120baac7-9937-4923-a039-9c344c30706c" />
