### PR TITLE
Add a trailing backslash to tag links generated by `make www`

### DIFF
--- a/themes/chapel-theme/layouts/posts/single.html
+++ b/themes/chapel-theme/layouts/posts/single.html
@@ -17,7 +17,7 @@
     <p>
         Tags:
         {{ range .Params.tags }}
-        <a class="button" href="{{ urls.JoinPath ( $.Site.BaseURL | relLangURL ) "tags" ( . | urlize ) }}">{{ . }}</a>
+        <a class="button" href="{{ urls.JoinPath ( $.Site.BaseURL | relLangURL ) "tags" ( . | urlize ) "/" }}">{{ . }}</a>
         {{ end }}
     </p>
     {{- end }}


### PR DESCRIPTION
While debugging Google Search console URLs, I noticed that our "tags" buttons on articles don't end with a trailing slash, so use "tags/vectorization" (say) rather than "tags/vectorization/".  Though the link still works (at least in browsers I've tested), this PR puts them into more of a canonical form to reduce exceptions.
