### PR TITLE
Remove use of deprecated variable and doubly-declared var

### DIFF
--- a/content/posts/chapelcon25-retro/index.md
+++ b/content/posts/chapelcon25-retro/index.md
@@ -4,7 +4,6 @@ date: 2025-12-05
 tags: ["ChapelCon", "Community"]
 series: []
 summary: "A retrospective on ChapelCon '25 from general chair Brandon Neth"
-weight: 15
 authors: ["Brandon Neth"]
 featured: true
 weight: -1

--- a/themes/chapel-theme/layouts/_default/rss.xml
+++ b/themes/chapel-theme/layouts/_default/rss.xml
@@ -1,4 +1,3 @@
-{{- /* Deprecate site.Author.email in favor of site.Params.author.email */}}
 {{- $authorEmail := "" }}
 {{- with site.Params.author }}
   {{- if reflect.IsMap . }}
@@ -6,14 +5,8 @@
       {{- $authorEmail = . }}
     {{- end }}
   {{- end }}
-{{- else }}
-  {{- with site.Author.email }}
-    {{- $authorEmail = . }}
-    {{- warnf "The author key in site configuration is deprecated. Use params.author.email instead." }}
-  {{- end }}
 {{- end }}
 
-{{- /* Deprecate site.Author.name in favor of site.Params.author.name */}}
 {{- $authorName := "" }}
 {{- with site.Params.author }}
   {{- if reflect.IsMap . }}
@@ -22,11 +15,6 @@
     {{- end }}
   {{- else }}
     {{- $authorName  = . }}
-  {{- end }}
-{{- else }}
-  {{- with site.Author.name }}
-    {{- $authorName = . }}
-    {{- warnf "The author key in site configuration is deprecated. Use params.author.name instead." }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This broke compatibility with newer Hugo versions.

Reviewed by @ShreyasKhandekar -- thanks!