### PR TITLE
Speedup `chpl_blog.py`.

### DIFF
--- a/scripts/chpl2md.py
+++ b/scripts/chpl2md.py
@@ -112,7 +112,7 @@ def extract_line_anchors(lines, line_no):
 
 def gen_md(pieces, chapelfile, **kwargs):
     output = []
-    good_options = compute_options(chapelfile)
+    good_options = kwargs.get('options') or compute_options(chapelfile)
     front_matter = []
 
     first_code_idx = -1

--- a/scripts/chpl2md.py
+++ b/scripts/chpl2md.py
@@ -206,12 +206,13 @@ def write(mdoutput, output):
 
 def main_args(**kwargs):
     """Driver function - convert each file to md and write to output"""
+    out = kwargs.get('out', sys.stdout)
     for chapelfile in kwargs['chapelfiles']:
         with open(chapelfile, 'r', encoding='utf-8') as handle:
             pieces = to_pieces(handle, False)
             mdoutput = (gen_code if kwargs['code'] else gen_md)(pieces, chapelfile, **kwargs)
 
-        sys.stdout.write(mdoutput)
+        out.write(mdoutput)
 
 def main():
     # Parse arguments and cast them into a dictionary

--- a/scripts/chpl_blog.py
+++ b/scripts/chpl_blog.py
@@ -10,7 +10,6 @@ import watchdog.events
 import watchdog.observers
 import subprocess
 import shutil
-import contextlib
 from pathlib import Path
 from common import compute_options
 import chpl2md
@@ -32,11 +31,9 @@ def create_output_dir_for(file):
 def generate_markdown(file, file_output_dir, options):
     base_name = os.path.basename(file).removesuffix(".chpl")
     with open(f"{file_output_dir}/index.md", "w") as f:
-        with contextlib.redirect_stdout(f):
-            chpl2md.main_args(chapelfiles=[file], code=False, code_path=f"code/{base_name}.chpl", options=options)
+        chpl2md.main_args(chapelfiles=[file], code=False, code_path=f"code/{base_name}.chpl", options=options, out=f)
     with open(f"{file_output_dir}/code/{base_name}.chpl", "w") as f:
-        with contextlib.redirect_stdout(f):
-            chpl2md.main_args(chapelfiles=[file], code=True, code_path=None, options=options)
+        chpl2md.main_args(chapelfiles=[file], code=True, code_path=None, options=options, out=f)
 
 def generate_chunks_for_option(file, file_output_dir, tmpdir, option):
     print("Processing option", option)

--- a/scripts/chpl_blog.py
+++ b/scripts/chpl_blog.py
@@ -10,12 +10,13 @@ import watchdog.events
 import watchdog.observers
 import subprocess
 import shutil
+import contextlib
 from pathlib import Path
 from common import compute_options
+import chpl2md
 
 input_dir = 'chpl-src'
 output_dir = "content-gen/posts"
-convert_script = os.path.dirname(__file__) + "/chpl2md.py"
 
 print("Deleting generated content folder {}".format(output_dir))
 shutil.rmtree(output_dir, ignore_errors=True)
@@ -30,10 +31,12 @@ def create_output_dir_for(file):
 
 def generate_markdown(file, file_output_dir):
     base_name = os.path.basename(file).removesuffix(".chpl")
-    command = "{} {} --code-path=code/{}.chpl > {}/index.md".format(convert_script, file, base_name, file_output_dir)
-    os.system(command)
-    command = "{} --code {} > {}/code/{}.chpl".format(convert_script, file, file_output_dir, base_name)
-    os.system(command)
+    with open(f"{file_output_dir}/index.md", "w") as f:
+        with contextlib.redirect_stdout(f):
+            chpl2md.main_args(chapelfiles=[file], code=False, code_path=f"code/{base_name}.chpl")
+    with open(f"{file_output_dir}/code/{base_name}.chpl", "w") as f:
+        with contextlib.redirect_stdout(f):
+            chpl2md.main_args(chapelfiles=[file], code=True, code_path=None)
 
 def generate_chunks_for_option(file, file_output_dir, tmpdir, option):
     print("Processing option", option)

--- a/scripts/chpl_blog.py
+++ b/scripts/chpl_blog.py
@@ -10,6 +10,7 @@ import watchdog.events
 import watchdog.observers
 import subprocess
 import shutil
+import concurrent.futures
 from pathlib import Path
 from common import compute_options
 import chpl2md
@@ -185,8 +186,8 @@ args = process_args()
 options = get_hugo_options(args)
 
 print("Creating initial Markdown and chunks for all files")
-for file in glob.glob(input_dir + "/*.chpl"):
-    process_file(file)
+with concurrent.futures.ThreadPoolExecutor() as executor:
+    executor.map(process_file, glob.glob(input_dir + "/*.chpl"))
 
 if args.command == 'build':
     print("Deleting Hugo output folder before re-generating")

--- a/scripts/chpl_blog.py
+++ b/scripts/chpl_blog.py
@@ -29,14 +29,14 @@ def create_output_dir_for(file):
     pathlib.Path(file_output_dir + "/code").mkdir(parents=True, exist_ok=True)
     return file_output_dir
 
-def generate_markdown(file, file_output_dir):
+def generate_markdown(file, file_output_dir, options):
     base_name = os.path.basename(file).removesuffix(".chpl")
     with open(f"{file_output_dir}/index.md", "w") as f:
         with contextlib.redirect_stdout(f):
-            chpl2md.main_args(chapelfiles=[file], code=False, code_path=f"code/{base_name}.chpl")
+            chpl2md.main_args(chapelfiles=[file], code=False, code_path=f"code/{base_name}.chpl", options=options)
     with open(f"{file_output_dir}/code/{base_name}.chpl", "w") as f:
         with contextlib.redirect_stdout(f):
-            chpl2md.main_args(chapelfiles=[file], code=True, code_path=None)
+            chpl2md.main_args(chapelfiles=[file], code=True, code_path=None, options=options)
 
 def generate_chunks_for_option(file, file_output_dir, tmpdir, option):
     print("Processing option", option)
@@ -75,21 +75,22 @@ def generate_chunks_for_option(file, file_output_dir, tmpdir, option):
         with open(chunk_path, "w") as chunkfile:
             chunkfile.write(chunk)
 
-def generate_chunks(file, file_output_dir):
+def generate_chunks(file, file_output_dir, options):
     with tempfile.TemporaryDirectory() as tmpdir:
-        for option in compute_options(file):
+        for option in options:
             generate_chunks_for_option(file, file_output_dir, tmpdir, option)
 
 def process_file(file):
-    print("Options:", compute_options(file))
+    options = compute_options(file)
+    print("Options:", options)
     print("Creating directory for", file)
     file_output_dir = create_output_dir_for(file)
     # we only generate external markdown for the link command, so no need for chunks
     if not args.fast and args.command != 'link':
         print("Generating chunks for", file)
-        generate_chunks(file, file_output_dir)
+        generate_chunks(file, file_output_dir, options)
     print("Generating Markdown for", file)
-    generate_markdown(file, file_output_dir)
+    generate_markdown(file, file_output_dir, options)
 
 class ChapelFileHandler(watchdog.events.FileSystemEventHandler):
     def on_created(self, event):


### PR DESCRIPTION
A few things.

* Take the hint from https://github.com/chapel-lang/chapel/pull/28822 and switch subprocess invocation of `chpl2md` to `import` + call.
* Avoid re-computing compilation options, especially because some files are executable, we re-run them several times. Compute once, thread through where possible.
  * Because we are now directly invoking `chpl2md` as a procedure, we can even thread the options through to it.
* Naively parallelize the loop that renders files using `ThreadPoolExecutor`.

The net effect is around a 7x improvement to the build. Combined with https://github.com/chapel-lang/chapel/pull/28822, this brings down `make www` on my machine from 48 seconds to 6 seconds.


Reviewed by @jabraham17 -- thanks!