### PR TITLE
Add new parallel testing support for the custom version-checking sub_test 

### DIFF
--- a/scripts/sub_test_help.py
+++ b/scripts/sub_test_help.py
@@ -4,6 +4,8 @@ import os
 import sys
 import subprocess
 import re
+import io
+import concurrent.futures
 from packaging import version
 
 # get the current Chapel version at $CHPL_HOME
@@ -40,6 +42,33 @@ def run_and_log(cmd):
     p.wait()
     return p.returncode
 
+# run 'sub_test' on a single file, with CHPL_ONETEST scoped to this file's own
+# subprocess environment (rather than mutating os.environ) so it is safe to call
+# from multiple threads. All output is captured and returned alongside the exit
+# code so the caller can emit it without interleaving concurrent runs.
+def run_sub_test_on_file(chpl_home_subtest, compiler, src_file):
+    env = os.environ.copy()
+    env["CHPL_ONETEST"] = os.path.basename(src_file)
+    p = subprocess.run(
+        [chpl_home_subtest, compiler],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    return p.returncode, p.stdout
+
+# determine how many worker threads to use for parallel sub_test runs.
+# returns 1 (serial) unless CHPL_PARALLEL_SUB_TEST is set: a positive integer
+# value selects that many workers, any other set value falls back to cpu count.
+def parallel_workers():
+    workers_env = os.environ.get("CHPL_PARALLEL_SUB_TEST")
+    if not workers_env:
+        return 1
+    if workers_env.isdigit() and int(workers_env) > 0:
+        return int(workers_env)
+    return os.cpu_count() or 1
+
 def run_valid_tests(version_validator, compiler):
     chpl_version = get_current_chpl_version(compiler)
     chpl_home_subtest = os.path.join(os.environ["CHPL_HOME"], "util", "test", "sub_test")
@@ -55,8 +84,31 @@ def run_valid_tests(version_validator, compiler):
         sys.stdout.write("[Filtering tests for chpl version: '{}']\n".format(chpl_version))
         sys.stdout.flush()
 
-        for src_file in chpl_files_in_dir("."):
-            if version_validator(src_file, chpl_version):
+        # select the files that satisfy the version constraint
+        valid_files = [
+            src_file
+            for src_file in chpl_files_in_dir(".")
+            if version_validator(src_file, chpl_version)
+        ]
+
+        num_workers = min(parallel_workers(), len(valid_files))
+
+        # opt-in parallel execution via CHPL_PARALLEL_SUB_TEST; capture each
+        # file's output and write it out in order so logs are not interleaved
+        if num_workers > 1:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+                results = executor.map(
+                    lambda src_file: run_sub_test_on_file(
+                        chpl_home_subtest, sys.argv[1], src_file
+                    ),
+                    valid_files,
+                )
+                for returncode, output in results:
+                    sys.stdout.write(output)
+                    sys.stdout.flush()
+                    err = max(err, returncode)
+        else:
+            for src_file in valid_files:
                 # set the src_file as the single test file for 'sub_test' to run
                 os.environ["CHPL_ONETEST"] = os.path.basename(src_file)
 


### PR DESCRIPTION
Adds support for running the blog tests in parallel through the custom version checking sub_test with https://github.com/chapel-lang/chapel/pull/29017

[Reviewed by @]